### PR TITLE
Add Okta support for OAuth login.

### DIFF
--- a/NetGoLynx/Controllers/AccountController.cs
+++ b/NetGoLynx/Controllers/AccountController.cs
@@ -36,7 +36,7 @@ namespace NetGoLynx.Controllers
         }
 
         /// <summary>
-        /// Log a user into Google.
+        /// Log a user in via Google.
         /// </summary>
         /// <returns>A redirect to the list view page.</returns>
         [HttpGet("Google")]
@@ -45,13 +45,13 @@ namespace NetGoLynx.Controllers
             return Challenge(
                 new AuthenticationProperties
                 {
-                    RedirectUri = Url.Action("List", "Redirect")
+                    RedirectUri = Url.Action("LoginSuccess", "Account")
                 },
                 Google.AuthenticationScheme);
         }
 
         /// <summary>
-        /// Log a user into GitHub.
+        /// Log a user in via GitHub.
         /// </summary>
         /// <returns>A redirect to the list view page.</returns>
         [HttpGet("GitHub")]
@@ -63,6 +63,21 @@ namespace NetGoLynx.Controllers
                     RedirectUri = Url.Action("LoginSuccess", "Account"),
                 },
                 GitHub.AuthenticationScheme);
+        }
+
+        /// <summary>
+        /// Log a user in via Okta.
+        /// </summary>
+        /// <returns>A redirect to the list view page.</returns>
+        [HttpGet("Okta")]
+        public async Task<IActionResult> LoginOktaAsync()
+        {
+            return Challenge(
+                new AuthenticationProperties
+                {
+                    RedirectUri = Url.Action("LoginSuccess", "Account"),
+                },
+                Okta.AuthenticationScheme);
         }
 
         /// <summary>

--- a/NetGoLynx/Models/Accounts/LoginModel.cs
+++ b/NetGoLynx/Models/Accounts/LoginModel.cs
@@ -6,10 +6,12 @@
 
         public LoginModel(
             bool isGoogleEnabled = false,
-            bool isGitHubEnabled = false)
+            bool isGitHubEnabled = false,
+            bool isOktaEnabled = false)
         {
             IsGoogleEnabled = isGoogleEnabled;
             IsGitHubEnabled = isGitHubEnabled;
+            IsOktaEnabled = isOktaEnabled;
         }
 
         public LoginModel(string[] schemas)
@@ -24,6 +26,9 @@
                     case "Google":
                         IsGoogleEnabled = true;
                         break;
+                    case "Okta":
+                        IsOktaEnabled = true;
+                        break;
                 }
             }
         }
@@ -31,5 +36,7 @@
         public bool IsGoogleEnabled { get; }
 
         public bool IsGitHubEnabled { get; }
+
+        public bool IsOktaEnabled { get; }
     }
 }

--- a/NetGoLynx/Models/Configuration/Authentication/Okta.cs
+++ b/NetGoLynx/Models/Configuration/Authentication/Okta.cs
@@ -1,0 +1,57 @@
+﻿using System;
+
+namespace NetGoLynx.Models.Configuration.Authentication
+{
+    /// <summary>
+    /// Describes a configuration object for Okta.
+    /// </summary>
+    /// <remarks>
+    /// To get this information, create a new Okta web app in your okta
+    /// </remarks>
+    public class Okta
+    {
+        /// <summary>
+        /// Gets a value indicating whether this configuration element is enabled. Defaults to false.
+        /// </summary>
+        /// <remarks>
+        /// If this configuration section is missing, this value will indicate that the other values
+        /// in this configuration are not valid and should be discarded.
+        /// </remarks>
+        public bool Enabled => !string.IsNullOrEmpty(ClientId);
+
+        /// <summary>
+        /// The OAuth Client ID
+        /// </summary>
+        public string ClientId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the OAuth Client Secret
+        /// </summary>
+        public string ClientSecret { get; set; }
+
+        /// <summary>
+        /// Gets or sets the OAuth auth endpoint URL
+        /// </summary>
+        public string AuthorizationEndpoint => $"{OktaDomain}/oauth2/default/v1/authorize";
+
+        /// <summary>
+        /// Gets or sets the OAuth token endpoint URL
+        /// </summary>
+        public string TokenEndpoint => $"{OktaDomain}/oauth2/default/v1/token";
+
+        /// <summary>
+        /// Gets or sets the user information URL
+        /// </summary>
+        public string UserInformationEndpoint => $"{OktaDomain}/oauth2/default/v1/userinfo";
+
+        /// <summary>
+        /// Gets or sets the okta domain.
+        /// </summary>
+        public Uri OktaDomain { get; set; }
+
+        /// <summary>
+        /// Gets the authentication scheme for Google OAuth.
+        /// </summary>
+        public static string AuthenticationScheme => "Okta";
+    }
+}

--- a/NetGoLynx/Views/Account/Login.cshtml
+++ b/NetGoLynx/Views/Account/Login.cshtml
@@ -21,6 +21,10 @@
             {
                 <a class="btn btn-info" asp-controller="Account" asp-action="LoginGoogle">Login with Google</a>
             }
+            @if (Model.IsOktaEnabled)
+            {
+                <a class="btn btn-info" asp-controller="Account" asp-action="LoginOkta">Login with Okta</a>
+            }
         }
     </div>
     <div class="col"></div>

--- a/NetGoLynx/appsettings.json
+++ b/NetGoLynx/appsettings.json
@@ -20,6 +20,11 @@
     "Google": {
       "ClientId": "This is very not real",
       "ClientSecret": "Also not real!"
+    },
+    "Okta": {
+      "ClientId": "This is not very real!",
+      "ClientSecret": "Still not real at all!",
+      "OktaDomain": "URL of your okta account with no trailing slash!"
     }
   }
 }


### PR DESCRIPTION
This closes #12 by adding Okta as an OAuth provider.

Future work includes making it easier to add a bunch of OAuth providers for flexibility and making everything involved with that much more dynamic. Having one giant startup.cs seems like a bad idea.

Okta is not supported in aspnet-contrib/AspNet.Security.OAuth.Providers at this time so it's implemented manually here following their dev guide: https://developer.okta.com/blog/2019/07/12/secure-your-aspnet-core-app-with-oauth