### PR TITLE
Implement fix for Chrome SameSite cookie changes

### DIFF
--- a/NetGoLynx/CookieHandler.cs
+++ b/NetGoLynx/CookieHandler.cs
@@ -1,0 +1,75 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace NetGoLynx
+{
+    /// <summary>
+    /// Methods for handling cookie specifics
+    /// </summary>
+    internal static class CookieHandler
+    {
+        /// <summary>
+        /// Modify SameSite parameter iff the destination browser won't handle 'None'.
+        /// </summary>
+        /// <param name="httpContext">The HTTP request context for the cookie.</param>
+        /// <param name="options">The cookie options.</param>
+        public static void CheckSameSite(HttpContext httpContext, CookieOptions options)
+        {
+            if (options.SameSite == SameSiteMode.None)
+            {
+                var userAgent = httpContext.Request.Headers["User-Agent"].ToString();
+                if (DisallowsSameSiteNone(userAgent))
+                {
+                    options.SameSite = SameSiteMode.Unspecified;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Determine if the user agent won't handle SameSite = None properly.
+        /// </summary>
+        /// <param name="userAgent">The user agent to parse</param>
+        /// <returns>True if SameSite=None will cause problems.</returns>
+        /// <remarks>
+        /// This is a user-agent sniffing method that will need to be updated from time tot ime
+        /// </remarks>
+        private static bool DisallowsSameSiteNone(string userAgent)
+        {
+            if (string.IsNullOrEmpty(userAgent))
+            {
+                return false;
+            }
+
+            // Cover all iOS based browsers here. This includes:
+            // - Safari on iOS 12 for iPhone, iPod Touch, iPad
+            // - WkWebview on iOS 12 for iPhone, iPod Touch, iPad
+            // - Chrome on iOS 12 for iPhone, iPod Touch, iPad
+            // All of which are broken by SameSite=None, because they use the iOS networking stack
+            if (userAgent.Contains("CPU iPhone OS 12") || userAgent.Contains("iPad; CPU OS 12"))
+            {
+                return true;
+            }
+
+            // Cover Mac OS X based browsers that use the Mac OS networking stack. This includes:
+            // - Safari on Mac OS X.
+            // This does not include:
+            // - Chrome on Mac OS X
+            // Because they do not use the Mac OS networking stack.
+            if (userAgent.Contains("Macintosh; Intel Mac OS X 10_14") &&
+                userAgent.Contains("Version/") && userAgent.Contains("Safari"))
+            {
+                return true;
+            }
+
+            // Cover Chrome 50-69, because some versions are broken by SameSite=None,
+            // and none in this range require it.
+            // Note: this covers some pre-Chromium Edge versions,
+            // but pre-Chromium Edge does not require SameSite=None.
+            if (userAgent.Contains("Chrome/5") || userAgent.Contains("Chrome/6"))
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/NetGoLynx/NetGoLynx.csproj
+++ b/NetGoLynx/NetGoLynx.csproj
@@ -12,19 +12,19 @@
 
 
   <ItemGroup>
-    <PackageReference Include="AspNet.Security.OAuth.GitHub" Version="3.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="3.1.2" />
+    <PackageReference Include="AspNet.Security.OAuth.GitHub" Version="3.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="3.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.4">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.2" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.10" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.1" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.7" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.4" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.4" />
   </ItemGroup>
 
 

--- a/NetGoLynx/Startup.cs
+++ b/NetGoLynx/Startup.cs
@@ -74,6 +74,13 @@ namespace NetGoLynx
 
             services.AddDbContext<RedirectContext>(GetDatabaseContext);
 
+            services.Configure<CookiePolicyOptions>(options =>
+            {
+                options.MinimumSameSitePolicy = SameSiteMode.Unspecified;
+                options.OnAppendCookie = c => CookieHandler.CheckSameSite(c.Context, c.CookieOptions);
+                options.OnDeleteCookie = c => CookieHandler.CheckSameSite(c.Context, c.CookieOptions);
+            });
+
             // Conditionally chain together calls to add auth providers.
             var auth = services.AddAuthentication(options =>
             {
@@ -124,6 +131,7 @@ namespace NetGoLynx
             app.UseStaticFiles();
             app.UseRouting();
 
+            app.UseCookiePolicy();
             app.UseAuthentication();
             app.UseAuthorization();
 


### PR DESCRIPTION
Chrome rolled out the SameSite=None requirement for cookies to be handled by things like OAuth requests. This implements the necessary fixes to make that workflow, well, work.